### PR TITLE
chore: test-python-jenkinsx to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.118
 - name: test-python-jenkinsx
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.9


### PR DESCRIPTION
chore: Promote test-python-jenkinsx to version 0.0.9